### PR TITLE
infra: add drop counter "no_headroom"

### DIFF
--- a/modules/infra/datapath/drop.c
+++ b/modules/infra/datapath/drop.c
@@ -19,3 +19,6 @@ drop_packets(struct rte_graph *graph, struct rte_node *node, void **objs, uint16
 
 	return nb_objs;
 }
+
+// Global drop counters, used by multiple nodes
+GR_DROP_REGISTER(error_no_headroom);


### PR DESCRIPTION
rte_pktmbuf_prepend returns null pointer when there is no available headroom.
Drop and count these packets.