### PR TITLE
net: remove gr_ prefix in frequently used functions

### DIFF
--- a/api/gr_net_types.h
+++ b/api/gr_net_types.h
@@ -22,16 +22,16 @@ struct eth_addr {
 	uint8_t bytes[6];
 };
 
-static inline bool gr_eth_addr_eq(const struct eth_addr *a, const struct eth_addr *b) {
+static inline bool eth_addr_eq(const struct eth_addr *a, const struct eth_addr *b) {
 	return memcmp(a->bytes, b->bytes, sizeof(a->bytes)) == 0;
 }
 
-static inline bool gr_eth_addr_is_zero(const struct eth_addr *mac) {
+static inline bool eth_addr_is_zero(const struct eth_addr *mac) {
 	struct eth_addr zero = {0};
-	return gr_eth_addr_eq(mac, &zero);
+	return eth_addr_eq(mac, &zero);
 }
 
-static inline int gr_eth_addr_parse(const char *s, struct eth_addr *mac) {
+static inline int eth_addr_parse(const char *s, struct eth_addr *mac) {
 	if (s == NULL)
 		goto err;
 	int ret = sscanf(
@@ -53,8 +53,9 @@ err:
 }
 
 #define IPV4_ATOM "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]|[0-9])"
-#define IPV4_RE "^" IPV4_ATOM "(\\." IPV4_ATOM "){3}$"
-#define IPV4_NET_RE "^" IPV4_ATOM "(\\." IPV4_ATOM "){3}/(3[0-2]|[12][0-9]|[0-9])$"
+#define __IPV4_RE IPV4_ATOM "(\\." IPV4_ATOM "){3}"
+#define IPV4_RE "^" __IPV4_RE "$"
+#define IPV4_NET_RE "^" __IPV4_RE "/(3[0-2]|[12][0-9]|[0-9])$"
 
 typedef uint32_t ip4_addr_t;
 
@@ -63,7 +64,7 @@ struct ip4_net {
 	uint8_t prefixlen;
 };
 
-static inline int gr_ip4_net_parse(const char *s, struct ip4_net *net, bool zero_mask) {
+static inline int ip4_net_parse(const char *s, struct ip4_net *net, bool zero_mask) {
 	char *addr = NULL;
 	int ret = -1;
 
@@ -89,7 +90,7 @@ out:
 	return ret;
 }
 
-static inline int gr_ip4_net_format(const struct ip4_net *net, char *buf, size_t len) {
+static inline int ip4_net_format(const struct ip4_net *net, char *buf, size_t len) {
 	const char *tmp;
 	int n;
 

--- a/cli/ecoli.c
+++ b/cli/ecoli.c
@@ -154,7 +154,7 @@ int arg_eth_addr(const struct ec_pnode *p, const char *id, struct eth_addr *val)
 	}
 	const char *str = ec_strvec_val(v, 0);
 
-	if (gr_eth_addr_parse(str, val) < 0) {
+	if (eth_addr_parse(str, val) < 0) {
 		errno = EINVAL;
 		goto err;
 	}

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -63,7 +63,7 @@ static uint64_t parse_port_args(
 		}
 		memccpy(port->devargs, devargs, 0, sizeof(port->devargs));
 	}
-	if (gr_eth_addr_parse(arg_str(p, "MAC"), &port->mac) == 0)
+	if (eth_addr_parse(arg_str(p, "MAC"), &port->mac) == 0)
 		set_attrs |= GR_PORT_SET_MAC;
 
 	if (arg_u16(p, "N_RXQ", &port->n_rxq) == 0)

--- a/modules/infra/cli/vlan.c
+++ b/modules/infra/cli/vlan.c
@@ -71,7 +71,7 @@ static uint64_t parse_vlan_args(
 	if (arg_u16(p, "VLAN", &vlan->vlan_id) == 0)
 		set_attrs |= GR_VLAN_SET_VLAN;
 
-	if (gr_eth_addr_parse(arg_str(p, "MAC"), &vlan->mac) == 0) {
+	if (eth_addr_parse(arg_str(p, "MAC"), &vlan->mac) == 0) {
 		set_attrs |= GR_VLAN_SET_MAC;
 	} else if (!update) {
 		const struct gr_iface_info_port *port;

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -304,7 +304,7 @@ int iface_port_reconfig(
 	if (set_attrs & GR_IFACE_SET_VRF)
 		iface->vrf_id = vrf_id;
 
-	if ((set_attrs & GR_PORT_SET_MAC) && !gr_eth_addr_is_zero(&api->mac)) {
+	if ((set_attrs & GR_PORT_SET_MAC) && !eth_addr_is_zero(&api->mac)) {
 		struct rte_ether_addr mac;
 		memcpy(&mac, &api->mac, sizeof(mac));
 		if ((ret = rte_eth_dev_default_mac_addr_set(p->port_id, &mac)) < 0)

--- a/modules/ip/cli/address.c
+++ b/modules/ip/cli/address.c
@@ -19,7 +19,7 @@ static cmd_status_t addr_add(const struct gr_api_client *c, const struct ec_pnod
 	struct gr_ip4_addr_add_req req = {.exist_ok = true};
 	struct gr_iface iface;
 
-	if (gr_ip4_net_parse(arg_str(p, "IP_NET"), &req.addr.addr, false) < 0)
+	if (ip4_net_parse(arg_str(p, "IP_NET"), &req.addr.addr, false) < 0)
 		return CMD_ERROR;
 	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
 		return CMD_ERROR;
@@ -35,7 +35,7 @@ static cmd_status_t addr_del(const struct gr_api_client *c, const struct ec_pnod
 	struct gr_ip4_addr_del_req req = {.missing_ok = true};
 	struct gr_iface iface;
 
-	if (gr_ip4_net_parse(arg_str(p, "IP_NET"), &req.addr.addr, false) < 0)
+	if (ip4_net_parse(arg_str(p, "IP_NET"), &req.addr.addr, false) < 0)
 		return CMD_ERROR;
 	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
 		return CMD_ERROR;
@@ -80,7 +80,7 @@ static cmd_status_t addr_list(const struct gr_api_client *c, const struct ec_pno
 	for (size_t i = 0; i < resp->n_addrs; i++) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		const struct gr_ip4_ifaddr *addr = &resp->addrs[i];
-		gr_ip4_net_format(&addr->addr, buf, sizeof(buf));
+		ip4_net_format(&addr->addr, buf, sizeof(buf));
 		if (iface_from_id(c, addr->iface_id, &iface) == 0)
 			scols_line_sprintf(line, 0, "%s", iface.name);
 		else

--- a/modules/ip/cli/nexthop.c
+++ b/modules/ip/cli/nexthop.c
@@ -24,7 +24,7 @@ static cmd_status_t nh4_add(const struct gr_api_client *c, const struct ec_pnode
 		errno = EINVAL;
 		return CMD_ERROR;
 	}
-	if (gr_eth_addr_parse(arg_str(p, "MAC"), &req.nh.mac) < 0)
+	if (eth_addr_parse(arg_str(p, "MAC"), &req.nh.mac) < 0)
 		return CMD_ERROR;
 	if (iface_from_name(c, arg_str(p, "IFACE"), &iface) < 0)
 		return CMD_ERROR;

--- a/modules/ip/cli/route.c
+++ b/modules/ip/cli/route.c
@@ -18,7 +18,7 @@
 static cmd_status_t route4_add(const struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_add_req req = {.exist_ok = true};
 
-	if (gr_ip4_net_parse(arg_str(p, "DEST"), &req.dest, true) < 0)
+	if (ip4_net_parse(arg_str(p, "DEST"), &req.dest, true) < 0)
 		return CMD_ERROR;
 	if (inet_pton(AF_INET, arg_str(p, "NH"), &req.nh) != 1) {
 		errno = EINVAL;
@@ -36,7 +36,7 @@ static cmd_status_t route4_add(const struct gr_api_client *c, const struct ec_pn
 static cmd_status_t route4_del(const struct gr_api_client *c, const struct ec_pnode *p) {
 	struct gr_ip4_route_del_req req = {.missing_ok = true};
 
-	if (gr_ip4_net_parse(arg_str(p, "DEST"), &req.dest, true) < 0)
+	if (ip4_net_parse(arg_str(p, "DEST"), &req.dest, true) < 0)
 		return CMD_ERROR;
 	if (arg_u16(p, "VRF", &req.vrf_id) < 0 && errno != ENOENT)
 		return CMD_ERROR;
@@ -75,7 +75,7 @@ static cmd_status_t route4_list(const struct gr_api_client *c, const struct ec_p
 	for (size_t i = 0; i < resp->n_routes; i++) {
 		struct libscols_line *line = scols_table_new_line(table, NULL);
 		const struct gr_ip4_route *route = &resp->routes[i];
-		gr_ip4_net_format(&route->dest, dest, sizeof(dest));
+		ip4_net_format(&route->dest, dest, sizeof(dest));
 		inet_ntop(AF_INET, &route->nh, nh, sizeof(nh));
 		scols_line_set_data(line, 0, dest);
 		scols_line_set_data(line, 1, nh);


### PR DESCRIPTION
This makes lines shorter and everyone is happy.