### PR TITLE
ci: add missing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     env:
       REVISION_RANGE: "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
     steps:
-      - run: dnf install -y make clang-tools-extra git
+      - run: dnf install -y make clang-tools-extra git jq curl
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # force fetch all history

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ also in scripts one command at a time, or by batches.
 ```sh
 dnf install gcc git libcmocka-devel libedit-devel libevent-devel make meson \
         ninja-build numactl-devel pkgconf python3-pyelftools scdoc \
-        libsmartcols-devel clang-tools-extra
+        libsmartcols-devel clang-tools-extra jq curl
 ```
 
 or
@@ -83,7 +83,7 @@ or
 ```sh
 apt install git build-essential gcovr libcmocka-dev libedit-dev libevent-dev \
         libnuma-dev meson ninja-build pkg-config python3-pyelftools scdoc \
-        libsmartcols-dev clang-format
+        libsmartcols-dev clang-format jq curl
 ```
 
 ### Build

--- a/devtools/check-patches
+++ b/devtools/check-patches
@@ -47,7 +47,7 @@ check_issue() {
 		-H "Accept: application/vnd.github+json" \
 		-H "X-GitHub-Api-Version: 2022-11-28" \
 		"$api_url/issues/${1##*/}") || return 1
-	test $(echo "$json" | jq -r .state) = open
+	test "$(echo "$json" | jq -r .state)" = open
 }
 
 for rev in $revisions; do


### PR DESCRIPTION
Fix the following errors in the lint job:

 devtools/check-patches: line 50: jq: command not found
 devtools/check-patches: line 50: test: =: unary operator expected