### PR TITLE
graph: sanitize dynamic node attach to parent

### DIFF
--- a/modules/infra/datapath/control_input.c
+++ b/modules/infra/datapath/control_input.c
@@ -30,14 +30,10 @@ static struct rte_mempool *control_input_pool;
 static rte_edge_t control_input_edges[1 << 8] = {UNKNOWN_CONTROL_INPUT_TYPE};
 
 void gr_control_input_add_handler(control_input_t type, const char *node_name) {
-	rte_edge_t edge = gr_node_attach_parent("control_input", node_name);
-	if (edge == RTE_EDGE_ID_INVALID)
-		ABORT("gr_node_attach_parent(control_input, lldp_output) failed");
-	if (control_input_edges[type] != UNKNOWN_CONTROL_INPUT_TYPE) {
-		ABORT("control_input: type=0x%04x -> already set to edge %u", type, edge);
-	}
-	control_input_edges[type] = edge;
-	LOG(DEBUG, "control_input: type=0x%04x -> edge %u", type, edge);
+	LOG(DEBUG, "control_input: type=%u -> %s", type, node_name);
+	if (control_input_edges[type] != UNKNOWN_CONTROL_INPUT_TYPE)
+		ABORT("control_input: handler for type=%u is already registered", type);
+	control_input_edges[type] = gr_node_attach_parent("control_input", node_name);
 }
 
 int post_to_stack(control_input_t type, void *data) {

--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -21,12 +21,9 @@ enum {
 
 static rte_edge_t l2l3_edges[1 << 16] = {UNKNOWN_ETHER_TYPE};
 
-void gr_eth_input_add_type(rte_be16_t eth_type, const char *node_name) {
-	rte_edge_t edge = gr_node_attach_parent("eth_input", node_name);
-	if (edge == RTE_EDGE_ID_INVALID)
-		ABORT("gr_node_attach_parent(eth_input, %s) failed", node_name);
-	l2l3_edges[eth_type] = edge;
-	LOG(DEBUG, "eth_input: type=0x%04x -> edge %u", rte_be_to_cpu_16(eth_type), edge);
+void gr_eth_input_add_type(rte_be16_t eth_type, const char *next_node) {
+	LOG(DEBUG, "eth_input: type=0x%04x -> %s", rte_be_to_cpu_16(eth_type), next_node);
+	l2l3_edges[eth_type] = gr_node_attach_parent("eth_input", next_node);
 }
 
 static uint16_t

--- a/modules/ip/datapath/gr_ip4_datapath.h
+++ b/modules/ip/datapath/gr_ip4_datapath.h
@@ -33,8 +33,8 @@ GR_MBUF_PRIV_DATA_TYPE(ip_local_mbuf_data, {
 	uint8_t proto;
 });
 
-void ip_input_local_add_proto(uint8_t proto, const char *node_name);
-void ip_output_add_tunnel(uint16_t iface_type_id, rte_edge_t edge);
+void ip_input_local_add_proto(uint8_t proto, const char *next_node);
+void ip_output_add_tunnel(uint16_t iface_type_id, const char *next_node);
 int arp_output_request_solicit(struct nexthop *nh);
 
 #define IPV4_VERSION_IHL 0x45

--- a/modules/ip/datapath/ip_local.c
+++ b/modules/ip/datapath/ip_local.c
@@ -13,12 +13,9 @@
 #define UNKNOWN_PROTO 0
 static rte_edge_t edges[256] = {UNKNOWN_PROTO};
 
-void ip_input_local_add_proto(uint8_t proto, const char *node_name) {
-	rte_edge_t edge = gr_node_attach_parent("ip_input_local", node_name);
-	if (edge == RTE_EDGE_ID_INVALID)
-		ABORT("gr_node_attach_parent(ip_input_local, %s) failed", node_name);
-	edges[proto] = edge;
-	LOG(DEBUG, "ip_input_local: proto=%u -> edge %u", proto, edge);
+void ip_input_local_add_proto(uint8_t proto, const char *next_node) {
+	LOG(DEBUG, "ip_input_local: proto=%u -> %s", proto, next_node);
+	edges[proto] = gr_node_attach_parent("ip_input_local", next_node);
 }
 
 static uint16_t ip_input_local_process(

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -29,9 +29,9 @@ enum {
 
 static rte_edge_t edges[128] = {ETH_OUTPUT};
 
-void ip_output_add_tunnel(uint16_t iface_type_id, rte_edge_t edge) {
-	edges[iface_type_id] = edge;
-	LOG(DEBUG, "ip_output: iface_type=%u -> edge %u", iface_type_id, edge);
+void ip_output_add_tunnel(uint16_t iface_type_id, const char *next_node) {
+	LOG(DEBUG, "ip_output: iface_type=%u -> %s", iface_type_id, next_node);
+	edges[iface_type_id] = gr_node_attach_parent("ip_output", next_node);
 }
 
 typedef enum {

--- a/modules/ipip/datapath_out.c
+++ b/modules/ipip/datapath_out.c
@@ -74,10 +74,7 @@ next:
 }
 
 static void ipip_output_register(void) {
-	rte_edge_t edge = gr_node_attach_parent("ip_output", "ipip_output");
-	if (edge == RTE_EDGE_ID_INVALID)
-		ABORT("gr_node_attach_parent(ip_output, ipip_output) failed");
-	ip_output_add_tunnel(GR_IFACE_TYPE_IPIP, edge);
+	ip_output_add_tunnel(GR_IFACE_TYPE_IPIP, "ipip_output");
 }
 
 static struct rte_node_register ipip_output_node = {


### PR DESCRIPTION
Rename node_name to next_node to make it more explicit.

Log the requested operation before actually calling gr_node_attach_parent so that is easier to debug in case of error.

Also update ip_output_add_tunnel to take a node name instead of an edge id.