### PR TITLE
graph: add duplicate checks for all dynamic nodes

### DIFF
--- a/modules/infra/datapath/control_input.c
+++ b/modules/infra/datapath/control_input.c
@@ -27,13 +27,15 @@ struct gr_control_input_msg {
 static struct rte_ring *control_input_ring;
 static struct rte_mempool *control_input_pool;
 
+static control_input_t next_id = 0;
 static rte_edge_t control_input_edges[1 << 8] = {UNKNOWN_CONTROL_INPUT_TYPE};
 
-void gr_control_input_add_handler(control_input_t type, const char *node_name) {
-	LOG(DEBUG, "control_input: type=%u -> %s", type, node_name);
-	if (control_input_edges[type] != UNKNOWN_CONTROL_INPUT_TYPE)
-		ABORT("control_input: handler for type=%u is already registered", type);
-	control_input_edges[type] = gr_node_attach_parent("control_input", node_name);
+control_input_t gr_control_input_register_handler(const char *node_name) {
+	if (next_id == 0xff)
+		ABORT("control_input: max number of handlers reached");
+	LOG(DEBUG, "control_input: type=%hhu -> %s", next_id, node_name);
+	control_input_edges[next_id] = gr_node_attach_parent("control_input", node_name);
+	return next_id++;
 }
 
 int post_to_stack(control_input_t type, void *data) {

--- a/modules/infra/datapath/eth_input.c
+++ b/modules/infra/datapath/eth_input.c
@@ -23,6 +23,9 @@ static rte_edge_t l2l3_edges[1 << 16] = {UNKNOWN_ETHER_TYPE};
 
 void gr_eth_input_add_type(rte_be16_t eth_type, const char *next_node) {
 	LOG(DEBUG, "eth_input: type=0x%04x -> %s", rte_be_to_cpu_16(eth_type), next_node);
+	if (l2l3_edges[eth_type] != UNKNOWN_ETHER_TYPE)
+		ABORT("next node already registered for ether type=0x%04x",
+		      rte_be_to_cpu_16(eth_type));
 	l2l3_edges[eth_type] = gr_node_attach_parent("eth_input", next_node);
 }
 

--- a/modules/infra/datapath/gr_control_input.h
+++ b/modules/infra/datapath/gr_control_input.h
@@ -8,14 +8,11 @@
 
 #include <rte_graph.h>
 
-typedef enum {
-	CONTROL_INPUT_UNKNOWN = 0,
-	CONTROL_INPUT_ARP_REQUEST
-} control_input_t;
-
 GR_MBUF_PRIV_DATA_TYPE(control_input_mbuf_data, { void *data; });
 
-void gr_control_input_add_handler(control_input_t type, const char *node_name);
+typedef uint8_t control_input_t;
+
+control_input_t gr_control_input_register_handler(const char *node_name);
 int post_to_stack(control_input_t type, void *data);
 
 #endif

--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -25,12 +25,14 @@ enum {
 	EDGE_COUNT,
 };
 
+static control_input_t arp_solicit;
+
 int arp_output_request_solicit(struct nexthop *nh) {
 	int ret;
 	if (nh == NULL)
 		return errno_set(EINVAL);
 	ip4_nexthop_incref(nh);
-	ret = post_to_stack(CONTROL_INPUT_ARP_REQUEST, nh);
+	ret = post_to_stack(arp_solicit, nh);
 	if (ret < 0) {
 		ip4_nexthop_decref(nh);
 		return errno_set(-ret);
@@ -106,7 +108,7 @@ next:
 }
 
 static void arp_output_request_register(void) {
-	gr_control_input_add_handler(CONTROL_INPUT_ARP_REQUEST, "arp_output_request");
+	arp_solicit = gr_control_input_register_handler("arp_output_request");
 }
 
 static struct rte_node_register arp_output_request_node = {

--- a/modules/ip/datapath/ip_local.c
+++ b/modules/ip/datapath/ip_local.c
@@ -14,7 +14,9 @@
 static rte_edge_t edges[256] = {UNKNOWN_PROTO};
 
 void ip_input_local_add_proto(uint8_t proto, const char *next_node) {
-	LOG(DEBUG, "ip_input_local: proto=%u -> %s", proto, next_node);
+	LOG(DEBUG, "ip_input_local: proto=%hhu -> %s", proto, next_node);
+	if (edges[proto] != UNKNOWN_PROTO)
+		ABORT("next node already registered for proto=%hhu", proto);
 	edges[proto] = gr_node_attach_parent("ip_input_local", next_node);
 }
 

--- a/modules/ip/datapath/ip_output.c
+++ b/modules/ip/datapath/ip_output.c
@@ -31,6 +31,10 @@ static rte_edge_t edges[128] = {ETH_OUTPUT};
 
 void ip_output_add_tunnel(uint16_t iface_type_id, const char *next_node) {
 	LOG(DEBUG, "ip_output: iface_type=%u -> %s", iface_type_id, next_node);
+	if (iface_type_id == GR_IFACE_TYPE_UNDEF || iface_type_id >= ARRAY_DIM(edges))
+		ABORT("invalid iface type=%u", iface_type_id);
+	if (edges[iface_type_id] != ETH_OUTPUT)
+		ABORT("next node already registered for iface type=%u", iface_type_id);
 	edges[iface_type_id] = gr_node_attach_parent("ip_output", next_node);
 }
 


### PR DESCRIPTION
Ensure we don't register two handlers for the same ether type, ip proto, tunnel output interface type or control input type.

To avoid storing information about other modules (IP/ARP) into the infra module, change `gr_control_input_register_handler` to automatically return the next available `control_input_t` value. That function cannot fail and will `ABORT()` if the available values are exhausted.

Fixes: 94a69675b5cb ("graph: sanitize dynamic node attach to parent")