### PR TITLE
ip: clean resources on iface deletion

### DIFF
--- a/api/gr_net_types.h
+++ b/api/gr_net_types.h
@@ -56,6 +56,8 @@ err:
 #define __IPV4_RE IPV4_ATOM "(\\." IPV4_ATOM "){3}"
 #define IPV4_RE "^" __IPV4_RE "$"
 #define IPV4_NET_RE "^" __IPV4_RE "/(3[0-2]|[12][0-9]|[0-9])$"
+#define IP4_ADDR_FMT "%d.%d.%d.%d"
+#define IP4_ADDR_SPLIT(b) ((uint8_t *)b)[0], ((uint8_t *)b)[1], ((uint8_t *)b)[2], ((uint8_t *)b)[3]
 
 typedef uint32_t ip4_addr_t;
 

--- a/modules/ip/control/gr_ip4_control.h
+++ b/modules/ip/control/gr_ip4_control.h
@@ -58,7 +58,7 @@ int ip4_route_insert(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen, uint32_t
 int ip4_route_delete(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen);
 struct nexthop *ip4_route_lookup(uint16_t vrf_id, ip4_addr_t ip);
 struct nexthop *ip4_route_lookup_exact(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen);
+void ip4_route_cleanup(uint16_t vrf_id, struct nexthop *nh);
 
 struct nexthop *ip4_addr_get(uint16_t iface_id);
-
 #endif

--- a/modules/ip/control/nexthop.c
+++ b/modules/ip/control/nexthop.c
@@ -323,6 +323,7 @@ static struct gr_module nh4_module = {
 	.name = "ipv4 nexthop",
 	.init = nh4_init,
 	.fini = nh4_fini,
+	.fini_prio = 20000,
 };
 
 RTE_INIT(control_ip_init) {


### PR DESCRIPTION
On iface deletion, delete assoticated routes.
specify module destructor priorities to ensure
resources are not freed when accessing them.