### PR TITLE
infra: fix null ptr access

### DIFF
--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -228,7 +228,7 @@ static void iface_fini(struct event_base *) {
 	// Destroy all virtual interface first before removing DPDK ports.
 	for (ifid = 0; ifid < MAX_IFACES; ifid++) {
 		iface = ifaces[ifid];
-		if (iface != NULL || iface->type_id != GR_IFACE_TYPE_PORT) {
+		if (iface != NULL && iface->type_id != GR_IFACE_TYPE_PORT) {
 			if (iface_destroy(ifid) < 0)
 				LOG(ERR, "iface_destroy: %s", strerror(errno));
 			ifaces[ifid] = NULL;


### PR DESCRIPTION
Fix null ptr access

I messed up when rebasing/rewriting code, and pushed the wrong patch, introducing a null ptr access when we quit grout.

Fixes: 8beb4d93a61a ("infra: destroy ports after logical interfaces")