### PR TITLE
iface: prevent port removal when subinterface exists

### DIFF
--- a/modules/infra/control/gr_iface.h
+++ b/modules/infra/control/gr_iface.h
@@ -20,6 +20,7 @@ struct __rte_cache_aligned iface {
 	uint16_t state;
 	uint16_t mtu;
 	uint16_t vrf_id; // L3 addressing and routing domain
+	uint8_t subinterfaces;
 	char *name;
 	alignas(alignof(void *)) uint8_t info[/* size depends on type */];
 };

--- a/modules/infra/control/iface.c
+++ b/modules/infra/control/iface.c
@@ -204,6 +204,9 @@ int iface_destroy(uint16_t ifid) {
 	if (iface == NULL)
 		return -1;
 
+	if (iface->subinterfaces > 0)
+		return errno_set(EBUSY);
+
 	iface_event_notify(IFACE_EVENT_PRE_REMOVE, iface);
 
 	ifaces[ifid] = NULL;

--- a/modules/infra/control/vlan.c
+++ b/modules/infra/control/vlan.c
@@ -156,10 +156,13 @@ static int iface_vlan_fini(struct iface *iface) {
 			status = ret;
 	}
 
+	iface_from_id(vlan->parent_id)->subinterfaces--;
+
 	return status;
 }
 
 static int iface_vlan_init(struct iface *iface, const void *api_info) {
+	struct iface_info_vlan *vlan = (struct iface_info_vlan *)iface->info;
 	int ret;
 
 	ret = iface_vlan_reconfig(
@@ -169,6 +172,8 @@ static int iface_vlan_init(struct iface *iface, const void *api_info) {
 		iface_vlan_fini(iface);
 		errno = -ret;
 	}
+
+	iface_from_id(vlan->parent_id)->subinterfaces++;
 
 	return ret;
 }


### PR DESCRIPTION
Physical port shouldn't be removed when a vlan interface depends on it.