### PR TITLE
ip: add function to get preferred iface address

### DIFF
--- a/modules/ip/control/gr_ip4_control.h
+++ b/modules/ip/control/gr_ip4_control.h
@@ -32,6 +32,13 @@ struct __rte_cache_aligned nexthop {
 	struct rte_mbuf *held_pkts_tail;
 };
 
+#define IP4_HOPLIST_MAX_SIZE 8
+
+struct hoplist {
+	unsigned count;
+	struct nexthop *nh[IP4_HOPLIST_MAX_SIZE];
+};
+
 // Max number of packets to hold per next hop waiting for resolution (default: 256).
 #define IP4_NH_MAX_HELD_PKTS 256
 // Reachable next hop lifetime after last ARP reply received (default: 20 min).
@@ -60,16 +67,9 @@ struct nexthop *ip4_route_lookup(uint16_t vrf_id, ip4_addr_t ip);
 struct nexthop *ip4_route_lookup_exact(uint16_t vrf_id, ip4_addr_t ip, uint8_t prefixlen);
 void ip4_route_cleanup(uint16_t vrf_id, struct nexthop *nh);
 
-#define IP4_MAX_IFACE_ADDRESSES 8
-
-struct iface_addresses {
-	struct nexthop *nh[IP4_MAX_IFACE_ADDRESSES];
-	unsigned count;
-};
-
 // get the default address for a given interface
-struct nexthop *ip4_addr_get_default(uint16_t iface_id);
+struct nexthop *ip4_addr_get_preferred(uint16_t iface_id, ip4_addr_t dst);
 // get all addresses for a given interface
-struct iface_addresses *ip4_addr_get_all(uint16_t iface_id);
+struct hoplist *ip4_addr_get_all(uint16_t iface_id);
 
 #endif

--- a/modules/ip/datapath/arp_input.c
+++ b/modules/ip/datapath/arp_input.c
@@ -103,9 +103,9 @@ arp_input_process(struct rte_graph *graph, struct rte_node *node, void **objs, u
 			goto next;
 		}
 
-		iface = eth_input_mbuf_data(mbuf)->iface;
-		local = ip4_addr_get_default(iface->id);
 		sip = arp->arp_data.arp_sip;
+		iface = eth_input_mbuf_data(mbuf)->iface;
+		local = ip4_addr_get_preferred(iface->id, sip);
 		remote = ip4_route_lookup(iface->vrf_id, sip);
 
 		if (remote != NULL && remote->ip == sip) {

--- a/modules/ip/datapath/arp_output_request.c
+++ b/modules/ip/datapath/arp_output_request.c
@@ -60,7 +60,7 @@ static uint16_t arp_output_request_process(
 	for (unsigned i = 0; i < n_objs; i++) {
 		mbuf = objs[i];
 		nh = (struct nexthop *)control_input_mbuf_data(mbuf)->data;
-		local = ip4_addr_get_default(nh->iface_id);
+		local = ip4_addr_get_preferred(nh->iface_id, nh->ip);
 		if (local == NULL) {
 			next = ERROR;
 			goto next;

--- a/modules/ip/datapath/ip_forward_error.c
+++ b/modules/ip/datapath/ip_forward_error.c
@@ -50,7 +50,7 @@ static uint16_t ip_forward_error_process(
 		// Get the local router IP address from the input iface
 		input_iface = ip_output_mbuf_data(mbuf)->input_iface;
 		vrf_id = input_iface->vrf_id;
-		if ((nh = ip4_addr_get_default(input_iface->id)) == NULL) {
+		if ((nh = ip4_addr_get_preferred(input_iface->id, ip->src_addr)) == NULL) {
 			rte_node_enqueue_x1(graph, node, NO_IP, mbuf);
 			continue;
 		}


### PR DESCRIPTION
In the datapath, we often need to get the correct IP address on an interface in order to reply or transmit a packet. Rename ip4_addr_get_default to ip4_addr_get_preferred which takes an additional destination IP address as argument. It will return the first address assigned to the interface that is in the same subnet.

If no address is found in that subnet, use the first address by default.

Rename struct iface_addresses to struct hoplist, the structure will be reused in order to support multiple next hops associated with a route prefix.

In a future commit, the next hops will need to be reordered so that the first address is the best default.