### PR TITLE
main: restrict logging to syslog when running under systemd

### DIFF
--- a/main/dpdk.c
+++ b/main/dpdk.c
@@ -17,13 +17,74 @@
 #include <rte_version.h>
 
 #include <sched.h>
+#include <stdio.h>
+#include <syslog.h>
 
 int gr_rte_log_type;
+static FILE *log_stream;
+static bool log_syslog;
+
+static ssize_t log_write(void *, const char *buf, size_t size) {
+	ssize_t n;
+	if (log_syslog) {
+		// Syslog error levels are from 0 to 7, so subtract 1 to convert.
+		syslog(rte_log_cur_msg_loglevel() - 1, "%.*s", (int)size, buf);
+		n = size;
+	} else {
+		const char *level;
+		switch (rte_log_cur_msg_loglevel()) {
+		case RTE_LOG_EMERG:
+			level = "EMERG";
+			break;
+		case RTE_LOG_ALERT:
+			level = "ALERT";
+			break;
+		case RTE_LOG_CRIT:
+			level = "CRIT";
+			break;
+		case RTE_LOG_ERR:
+			level = "ERR";
+			break;
+		case RTE_LOG_WARNING:
+			level = "WARN";
+			break;
+		case RTE_LOG_NOTICE:
+			level = "NOTICE";
+			break;
+		case RTE_LOG_INFO:
+			level = "INFO";
+			break;
+		case RTE_LOG_DEBUG:
+			level = "DEBUG";
+			break;
+		default:
+			level = "???";
+			break;
+		}
+		n = fprintf(stderr, "%s: %.*s", level, (int)size, buf);
+	}
+	return n;
+}
 
 int dpdk_init(struct gr_args *args) {
+	cookie_io_functions_t log_functions = {.write = log_write};
 	char main_lcore[32] = {0};
 	char **eal_args = NULL;
 	int ret;
+
+	if (getenv("JOURNAL_STREAM")) {
+		// executed by systemd with stderr redirected to journald
+		log_syslog = true;
+		openlog("grout", LOG_PID | LOG_ODELAY, LOG_DAEMON);
+	}
+
+	if ((log_stream = fopencookie(NULL, "w+", log_functions)) == NULL) {
+		ret = errno;
+		goto end;
+	}
+	rte_openlog_stream(log_stream);
+
+	LOG(INFO, "starting grout version %s", GROUT_VERSION);
 
 	for (unsigned cpu = 0; cpu < numa_all_cpus_ptr->size; cpu++) {
 		if (numa_bitmask_isbitset(numa_all_cpus_ptr, cpu)) {
@@ -86,4 +147,6 @@ end:
 
 void dpdk_fini(void) {
 	rte_eal_cleanup();
+	if (log_stream != NULL)
+		fclose(log_stream);
 }

--- a/main/main.c
+++ b/main/main.c
@@ -365,8 +365,6 @@ int main(int argc, char **argv) {
 	if (parse_args(argc, argv) < 0)
 		goto end;
 
-	LOG(INFO, "starting grout version %s", GROUT_VERSION);
-
 	if (dpdk_init(&args) < 0) {
 		err = errno;
 		goto dpdk_stop;


### PR DESCRIPTION
By default, DPDK log functions print both to stderr *and* syslog. This is not only unnecessary but also when running as a systemd service, it produces duplicated log lines.

When JOURNAL_STREAM is set in the environment, it indicates that grout has been started by systemd and its stderr is connected to the journal. If that is the case, log using syslog. Otherwise print on stderr prefixing the message with the textual value of the log level.