### PR TITLE
worker: allow starting threads outside of current process affinity

### DIFF
--- a/main/dpdk.c
+++ b/main/dpdk.c
@@ -72,8 +72,8 @@ int dpdk_init(struct gr_args *args) {
 	char **eal_args = NULL;
 	int ret;
 
-	if (getenv("JOURNAL_STREAM")) {
-		// executed by systemd with stderr redirected to journald
+	if (getenv("INVOCATION_ID")) {
+		// executed by systemd
 		log_syslog = true;
 		openlog("grout", LOG_PID | LOG_ODELAY, LOG_DAEMON);
 	}

--- a/main/dpdk.h
+++ b/main/dpdk.h
@@ -6,7 +6,8 @@
 
 #include "gr.h"
 
-int dpdk_init(struct gr_args *);
+int dpdk_log_init(const struct gr_args *);
+int dpdk_init(const struct gr_args *);
 void dpdk_fini(void);
 
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -365,6 +365,13 @@ int main(int argc, char **argv) {
 	if (parse_args(argc, argv) < 0)
 		goto end;
 
+	if (dpdk_log_init(&args) < 0) {
+		err = errno;
+		goto end;
+	}
+
+	LOG(NOTICE, "starting grout version %s", GROUT_VERSION);
+
 	if (dpdk_init(&args) < 0) {
 		err = errno;
 		goto dpdk_stop;

--- a/main/signals.c
+++ b/main/signals.c
@@ -15,7 +15,7 @@ static void signal_cb(evutil_socket_t sig, short what, void *priv) {
 
 	(void)what;
 
-	LOG(WARNING, "received signal SIG%s", sigabbrev_np(sig));
+	LOG(NOTICE, "received signal SIG%s", sigabbrev_np(sig));
 
 	switch (sig) {
 	case SIGPIPE:

--- a/modules/infra/control/meson.build
+++ b/modules/infra/control/meson.build
@@ -15,7 +15,6 @@ tests += [
   {
     'sources': files('worker_test.c', 'port.c', 'worker.c'),
     'link_args': [
-      '-Wl,--wrap=numa_bitmask_isbitset',
       '-Wl,--wrap=numa_node_of_cpu',
       '-Wl,--wrap=pthread_cancel',
       '-Wl,--wrap=pthread_create',

--- a/modules/infra/control/meson.build
+++ b/modules/infra/control/meson.build
@@ -17,6 +17,7 @@ tests += [
     'link_args': [
       '-Wl,--wrap=numa_bitmask_isbitset',
       '-Wl,--wrap=numa_node_of_cpu',
+      '-Wl,--wrap=pthread_cancel',
       '-Wl,--wrap=pthread_create',
       '-Wl,--wrap=pthread_join',
       '-Wl,--wrap=rte_dev_name',

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -82,6 +82,7 @@ mock_func(
 	int,
 	__wrap_rte_eth_dev_configure(uint16_t, uint16_t, uint16_t, const struct rte_eth_conf *)
 );
+mock_func(int, __wrap_pthread_cancel(pthread_t));
 mock_func(int, __wrap_pthread_create(pthread_t *, const pthread_attr_t *, void *(void *), void *));
 mock_func(int, __wrap_pthread_join(pthread_t *, const pthread_attr_t *, void *(void *), void *));
 mock_func(void *, __wrap_rte_zmalloc(char *, size_t, unsigned));
@@ -196,8 +197,12 @@ static void rxq_assign_main_lcore(void **) {
 }
 
 static void rxq_assign_invalid_cpu(void **) {
+	struct worker tmp;
 	will_return(__wrap_rte_get_main_lcore, 0);
-	will_return(__wrap_numa_bitmask_isbitset, 0);
+	will_return(__wrap_rte_zmalloc, &tmp);
+	will_return(__wrap_pthread_create, ERANGE);
+	will_return(__wrap_pthread_cancel, 0);
+	will_return(__wrap_rte_free, 0);
 	assert_int_equal(worker_rxq_assign(0, 0, 9999), -ERANGE);
 }
 

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -87,7 +87,6 @@ mock_func(int, __wrap_pthread_create(pthread_t *, const pthread_attr_t *, void *
 mock_func(int, __wrap_pthread_join(pthread_t *, const pthread_attr_t *, void *(void *), void *));
 mock_func(void *, __wrap_rte_zmalloc(char *, size_t, unsigned));
 mock_func(unsigned, __wrap_rte_get_main_lcore(void));
-mock_func(int, __wrap_numa_bitmask_isbitset(const struct bitmask *, int));
 
 #define assert_qmaps(qmaps, ...)                                                                   \
 	do {                                                                                       \
@@ -172,7 +171,6 @@ static int teardown(void **) {
 static void common_mocks(void) {
 	will_return_maybe(worker_graph_free, 0);
 	will_return_maybe(worker_graph_reload_all, 0);
-	will_return_maybe(__wrap_numa_bitmask_isbitset, 1);
 	will_return_maybe(__wrap_pthread_create, 0);
 	will_return_maybe(__wrap_pthread_join, 0);
 	will_return_maybe(__wrap_rte_dev_name, "");

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -120,7 +120,6 @@ void *gr_datapath_loop(void *priv) {
 	uint32_t sleep, max_sleep_us;
 	struct worker *w = priv;
 	struct rte_graph *graph;
-	rte_cpuset_t cpuset;
 	unsigned cur, loop;
 	char name[16];
 
@@ -132,13 +131,6 @@ void *gr_datapath_loop(void *priv) {
 
 	if (rte_thread_register() < 0) {
 		log(ERR, "rte_thread_register: %s", rte_strerror(rte_errno));
-		return NULL;
-	}
-
-	CPU_ZERO(&cpuset);
-	CPU_SET(w->cpu_id, &cpuset);
-	if (rte_thread_set_affinity(&cpuset) < 0) {
-		log(ERR, "rte_thread_set_affinity: %s", rte_strerror(rte_errno));
 		return NULL;
 	}
 

--- a/smoke/_init.sh
+++ b/smoke/_init.sh
@@ -33,7 +33,9 @@ cat > $tmp/cleanup <<EOF
 grcli show stats software
 grcli show interface all
 grcli show ip nexthop
+grcli show ip route
 grcli show ip6 nexthop
+grcli show ip6 route
 EOF
 
 set -x


### PR DESCRIPTION
When using tuned CPU partitioning, the default CPU affinity of processes are often restricted to a set of housekeeping cores. We want the control plane threads to run in these CPUs. However, we also want the data path threads NOT to run on these CPUs, but instead pin them on the previously isolated cores.

Remove the restriction of worker_rxq_assign() cpu_id to be part of the current process CPU affinity. Instead use a pthread attribute to specify the desired affinity based on cpu_id and pass that to pthread_create(). That way, if the cpu_id cannot be used (either because it is invalid or referencing to an offline CPU), pthread_create() will return an appropriate error code that can be returned to the caller. Since this call can now fail, delay the removal of the rxq from the source worker after the destination has been successfully created.

Remove the (now redundant) call to rte_thread_set_affinity() inside gr_datapath_loop().

Update unit tests accordingly.