### PR TITLE
port: use interrupt thread to monitor link status and speed

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -13,6 +13,7 @@
 #include <gr_macro.h>
 
 #include <event2/event.h>
+#include <event2/thread.h>
 #include <rte_eal.h>
 #include <rte_log.h>
 #include <rte_mempool.h>
@@ -361,7 +362,11 @@ int main(int argc, char **argv) {
 		perror("setlocale(LC_CTYPE, C.UTF-8)");
 		goto end;
 	}
-
+	if (evthread_use_pthreads() < 0) {
+		errno = ENOSYS;
+		perror("evthread_use_pthreads");
+		goto end;
+	}
 	if (parse_args(argc, argv) < 0)
 		goto end;
 

--- a/meson.build
+++ b/meson.build
@@ -45,7 +45,8 @@ dpdk_dep = dependency(
   ],
 )
 
-event_dep = dependency('libevent')
+ev_core_dep = dependency('libevent_core')
+ev_thread_dep = dependency('libevent_pthreads')
 numa_dep = dependency('numa')
 stb_dep = dependency('stb', fallback: ['stb', 'stb_dep'])
 ecoli_dep = dependency('libecoli', fallback: ['ecoli', 'libecoli_dep'])
@@ -70,7 +71,7 @@ subdir('cli')
 grout_exe = executable(
   'grout', src,
   include_directories: inc,
-  dependencies: [dpdk_dep, event_dep, numa_dep, stb_dep],
+  dependencies: [dpdk_dep, ev_core_dep, ev_thread_dep, numa_dep, stb_dep],
   install: true,
   install_dir: 'sbin',
 )
@@ -92,7 +93,7 @@ foreach t : tests
     'include_directories': inc + cli_inc,
     'c_args': ['-coverage'],
     'link_args': t['link_args'] + ['-lgcov'],
-    'dependencies': [dpdk_dep, event_dep, numa_dep, ecoli_dep, cmocka_dep, stb_dep],
+    'dependencies': [dpdk_dep, ev_core_dep, ev_thread_dep, numa_dep, ecoli_dep, cmocka_dep, stb_dep],
   }
   test(name, executable(name, kwargs: t), suite: 'unit')
 endforeach

--- a/modules/infra/api/graph.c
+++ b/modules/infra/api/graph.c
@@ -26,8 +26,8 @@ static struct api_out graph_dump(const void *request, void **response) {
 
 	STAILQ_FOREACH (worker, &workers, next) {
 		for (int i = 0; i < 2; i++) {
-			if (worker->config[i].graph != NULL) {
-				graph_name = worker->config[i].graph->name;
+			if (worker->graph[i] != NULL) {
+				graph_name = worker->graph[i]->name;
 				goto found;
 			}
 		}

--- a/modules/infra/control/gr_worker.h
+++ b/modules/infra/control/gr_worker.h
@@ -41,10 +41,8 @@ struct worker {
 	atomic_uint next_config; // dataplane: ro, ctlplane: rw
 	atomic_uint cur_config; // dataplane: wo, ctlplane: ro
 	// synced with thread_fence
-	struct {
-		struct rte_graph *graph;
-		uint32_t max_sleep_us;
-	} config[2]; // dataplane: ro, ctlplane: rw
+	struct rte_graph *graph[2]; // dataplane: ro, ctlplane: rw
+	atomic_uint max_sleep_us; // dataplane: ro, ctlplane: rw
 
 	atomic_bool stats_reset; // dataplane: rw, ctlplane: rw
 	// dataplane: wo, ctlplane: ro, may be NULL

--- a/modules/infra/control/worker_test.c
+++ b/modules/infra/control/worker_test.c
@@ -3,6 +3,7 @@
 
 #include "worker_priv.h"
 
+#include <gr.h>
 #include <gr_api.h>
 #include <gr_cmocka.h>
 #include <gr_control.h>
@@ -30,6 +31,15 @@ void iface_type_register(struct iface_type *) { }
 void iface_event_notify(iface_event_t, struct iface *) { }
 mock_func(struct rte_mempool *, gr_pktmbuf_pool_get(int8_t, uint32_t));
 void gr_pktmbuf_pool_release(struct rte_mempool *, uint32_t) { }
+
+struct gr_args args;
+const struct gr_args *gr_args(void) {
+	return &args;
+}
+
+struct iface *iface_from_id(uint16_t ifid) {
+	return ifid < ARRAY_DIM(ifaces) ? ifaces[ifid] : NULL;
+}
 
 struct iface *iface_next(uint16_t type_id, const struct iface *prev) {
 	uint16_t ifid;

--- a/modules/infra/datapath/main_loop.c
+++ b/modules/infra/datapath/main_loop.c
@@ -159,8 +159,7 @@ reconfig:
 		goto shutdown;
 
 	cur = atomic_load_explicit(&w->next_config, memory_order_acquire);
-	graph = w->config[cur].graph;
-	max_sleep_us = w->config[cur].max_sleep_us;
+	graph = w->graph[cur];
 	atomic_store_explicit(&w->cur_config, cur, memory_order_release);
 
 	if (graph == NULL) {
@@ -173,8 +172,6 @@ reconfig:
 	atomic_store(&w->stats, ctx.w_stats);
 
 	gr_modules_dp_init();
-
-	log(INFO, "reconfigured max_sleep=%uus", max_sleep_us);
 
 	loop = 0;
 	sleep = 0;
@@ -192,6 +189,7 @@ reconfig:
 			rte_graph_cluster_stats_get(ctx.stats, false);
 			timestamp_tmp = rte_rdtsc();
 			cycles = timestamp_tmp - timestamp;
+			max_sleep_us = atomic_load_explicit(&w->max_sleep_us, memory_order_relaxed);
 			if (ctx.last_count == 0 && max_sleep_us > 0) {
 				sleep = sleep == max_sleep_us ? sleep : (sleep + 1);
 				usleep(sleep);


### PR DESCRIPTION
The link status behind eth ports may change at any moment. The only way to get reliable information about the link status and speed is to rely on driver notifications via the link status check interrupt thread (enabled by default in DPDK).

Configure all ports with intr_conf.lsc=1 if supported by the driver. If not supported, the link status and speed will not be updated automatically.

Register an LSC ethdev callback which only serves as a proxy to trigger a libevent callback. That way, the link status information is checked and updated from the main lcore only. libevent needs to be initialized with pthread support to allow other threads to trigger events.