### PR TITLE
main: add flags to display version

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -23,7 +23,7 @@
 // Please keep options/flags in alphabetical order.
 
 static void usage(const char *prog) {
-	printf("Usage: %s [-e] [-f PATH] [-h] [-s PATH] [-x] ...\n", prog);
+	printf("Usage: %s [-e] [-f PATH] [-h] [-s PATH] [-V] [-x] ...\n", prog);
 	printf("       %s -c|--bash-complete\n", prog);
 }
 
@@ -38,6 +38,7 @@ static void help(void) {
 	puts("  -s PATH, --socket PATH     Path to the control plane API socket.");
 	puts("                             Default: GROUT_SOCK_PATH from env or");
 	printf("                             %s).\n", GR_DEFAULT_SOCK_PATH);
+	puts("  -V, --version              Print version and exit.");
 	puts("  -x, --trace-commands       Print executed commands.");
 	puts("");
 	puts("external completion:");
@@ -57,12 +58,13 @@ struct gr_cli_opts opts;
 static int parse_args(int argc, char **argv) {
 	int c;
 
-#define FLAGS ":ef:hs:x"
+#define FLAGS ":ef:hs:Vx"
 	static struct option long_options[] = {
 		{"err-exit", no_argument, NULL, 'e'},
 		{"file", required_argument, NULL, 'f'},
 		{"help", no_argument, NULL, 'h'},
 		{"socket", required_argument, NULL, 's'},
+		{"version", no_argument, NULL, 'V'},
 		{"trace-commands", no_argument, NULL, 'x'},
 		{0},
 	};
@@ -90,6 +92,10 @@ static int parse_args(int argc, char **argv) {
 			return -1;
 		case 's':
 			opts.sock_path = optarg;
+			break;
+		case 'V':
+			printf("grcli %s\n", GROUT_VERSION);
+			exit(EXIT_SUCCESS);
 			break;
 		case 'x':
 			opts.trace_commands = true;

--- a/docs/grcli.1.scd
+++ b/docs/grcli.1.scd
@@ -14,7 +14,7 @@ Grout is a software router based on DPDK rte_graph.
 
 ; Please keep flags/options in alphabetical order.
 
-*grcli* [*-e*] [*-f* _PATH_] [*-h*] [*-s* _PATH_] [*-x*] ...
+*grcli* [*-e*] [*-f* _PATH_] [*-h*] [*-s* _PATH_] [*-V*] [*-x*] ...
 
 # OPTIONS
 
@@ -28,6 +28,8 @@ Grout is a software router based on DPDK rte_graph.
 	Path to the control plane API socket.
 
 	Default: _GROUT_SOCK_PATH_ from env or _/run/grout.sock_).
+*-V*, *--version*
+	Print version and exit.
 *-x*, *--trace-commands*
 	Print executed commands.
 

--- a/docs/grout.8.scd
+++ b/docs/grout.8.scd
@@ -14,7 +14,7 @@ Grout is a software router based on DPDK rte_graph.
 
 ; Please keep flags/options in alphabetical order.
 
-*grout* [*-h*] [*-p*] [*-s* _PATH_] [*-t*] [*-v*] [*-x*]
+*grout* [*-h*] [*-p*] [*-s* _PATH_] [*-t*] [*-V*] [*-v*] [*-x*]
 
 # OPTIONS
 
@@ -28,6 +28,8 @@ Grout is a software router based on DPDK rte_graph.
 	Default: *GROUT_SOCK_PATH* from environment or _/run/grout.sock_).
 *-t*, *--test-mode*
 	Run in test mode (no huge pages).
+*-V*, *--version*
+	Print version and exit.
 *-v*, *--verbose*
 	Increase verbosity. Can be specified multiple times.
 *-x*, *--trace-packets*

--- a/main/main.c
+++ b/main/main.c
@@ -17,6 +17,7 @@
 #include <rte_eal.h>
 #include <rte_log.h>
 #include <rte_mempool.h>
+#include <rte_version.h>
 
 #include <fcntl.h>
 #include <getopt.h>
@@ -35,7 +36,7 @@
 // Please keep options/flags in alphabetical order.
 
 static void usage(const char *prog) {
-	printf("Usage: %s [-h] [-p] [-s PATH] [-t] [-v] [-x]\n", prog);
+	printf("Usage: %s [-h] [-p] [-s PATH] [-t] [-v] [-v] [-x]\n", prog);
 	puts("");
 	printf("  Graph router version %s.\n", GROUT_VERSION);
 	puts("");
@@ -46,6 +47,7 @@ static void usage(const char *prog) {
 	puts("                             Default: GROUT_SOCK_PATH from env or");
 	printf("                             %s).\n", GR_DEFAULT_SOCK_PATH);
 	puts("  -t, --test-mode            Run in test mode (no hugepages).");
+	puts("  -V, --version              Print version and exit.");
 	puts("  -v, --verbose              Increase verbosity.");
 	puts("  -x, --trace-packets        Print all ingress/egress packets.");
 }
@@ -60,12 +62,13 @@ const struct gr_args *gr_args(void) {
 static int parse_args(int argc, char **argv) {
 	int c;
 
-#define FLAGS ":hps:tvx"
+#define FLAGS ":hps:tVvx"
 	static struct option long_options[] = {
 		{"help", no_argument, NULL, 'h'},
 		{"poll-mode", no_argument, NULL, 'p'},
 		{"socket", required_argument, NULL, 's'},
 		{"test-mode", no_argument, NULL, 't'},
+		{"version", no_argument, NULL, 'V'},
 		{"verbose", no_argument, NULL, 'v'},
 		{"trace-packets", no_argument, NULL, 'x'},
 		{0},
@@ -89,6 +92,10 @@ static int parse_args(int argc, char **argv) {
 			break;
 		case 't':
 			args.test_mode = true;
+			break;
+		case 'V':
+			printf("grout %s (%s)\n", GROUT_VERSION, rte_version());
+			exit(EXIT_SUCCESS);
 			break;
 		case 'v':
 			args.log_level++;


### PR DESCRIPTION
Add -V, --version flags to both grout and grcli. When these flags are specified, print the program version and exit. Update the man pages and usage help accordingly.